### PR TITLE
Fix: route 'currency' column type to InputInt

### DIFF
--- a/core/InputFactory.tsx
+++ b/core/InputFactory.tsx
@@ -36,7 +36,7 @@ export function InputFactory(inputProps: any): JSX.Element {
           case 'password': inputToRender = <InputPassword {...inputProps} />; break;
           case 'text': inputToRender = <InputTextarea {...inputProps} />; break;
           case 'json': inputToRender = <InputTextarea {...inputProps} />; break;
-          case 'decimal': case 'int': inputToRender = <InputInt {...inputProps} />; break;
+          case 'decimal': case 'int': case 'currency': inputToRender = <InputInt {...inputProps} />; break;
           case 'boolean': inputToRender = <InputBoolean {...inputProps} />; break;
           case 'lookup': inputToRender = <InputLookup {...inputProps} />; break;
           case 'color': inputToRender = <InputColor {...inputProps} />; break;


### PR DESCRIPTION
`InputFactory`'s switch handled `'decimal'` and `'int'` but not `'currency'`,
so Currency fields fell through to `default` → `InputVarchar`.
Anything a user typed with a comma was rejected with `contains invalid value`.