### PR TITLE
show server error messages on rejected delete and save

### DIFF
--- a/core/Form.tsx
+++ b/core/Form.tsx
@@ -563,6 +563,8 @@ export default class Form<P, S> extends TranslatedComponent<FormProps, FormState
       },
       (err: any) => {
         this.setState({deletingRecord: false});
+        const message = err?.data?.message;
+        if (message) globalThis.hubleto.showDialogWarning(message);
       }
     );
   }
@@ -1281,7 +1283,7 @@ export default class Form<P, S> extends TranslatedComponent<FormProps, FormState
 
   renderSaveErrorMessage(): null|JSX.Element{
     return this.state.saveError && this.state.saveError.message
-      ? <div className='text-white bg-red-300 p-2'>{this.state.saveError.message}</div>
+      ? <div className='text-white bg-red-300 p-2 whitespace-pre-line'>{this.state.saveError.message}</div>
       : null
     ;
   }

--- a/core/Table.tsx
+++ b/core/Table.tsx
@@ -937,6 +937,13 @@ export default class Table<P, S> extends TranslatedComponent<TableProps, TableSt
             this.setState({data: data}, () => {
               this.loadData();
             });
+          },
+          (err: any) => {
+            const message = err?.data?.message;
+            if (message) globalThis.hubleto.showDialogWarning(message);
+            let data = this.state.data;
+            if (data && data.records[indexRecordToDelete]) delete data.records[indexRecordToDelete]._toBeDeleted_;
+            this.setState({data: data});
           }
         );
       }


### PR DESCRIPTION
When the server refuses an action and sends back a reason, that message is now shown to the user in a popup. Before, some of these messages were only printed to the browser console, so the  user saw "nothing happened" with no explanation.
  - Table.tsx – when a delete is rejected by the server, show the server's message in a popup, and un-mark the row that was about to be deleted (so it doesn't look stuck).
  - Form.tsx – same fix for deletes done from inside an open form.
  - Form.tsx – when the server returns several validation errors at once, show them on separate lines instead of all mashed together on one line.