### PR TITLE
Fix lookup input minimum width

### DIFF
--- a/core/Inputs/Lookup.tsx
+++ b/core/Inputs/Lookup.tsx
@@ -200,7 +200,7 @@ export default class Lookup<P, S> extends Input<LookupInputProps, LookupInputSta
           // allowCreateWhileLoading={false}
           // formatCreateLabel={(inputValue: string) => <span className="create-new">{this.translate('Create', 'Hubleto\\Erp\\Loader', 'Components\\Inputs\\Lookup') + ': ' + inputValue}</span>}
           // getNewOptionData={(value, label) => { return { id: {_isNew_: true, _LOOKUP: label}, _LOOKUP: label }; }}
-          styles={{ menuPortal: (base) => ({ ...base, zIndex: 9999 }) }}
+          styles={{ container: (base) => ({ ...base, minWidth: '16rem' }), menuPortal: (base) => ({ ...base, zIndex: 9999 }) }}
           menuPosition="fixed"
           menuPortalTarget={document.body}
         />


### PR DESCRIPTION
Prevent lookup fields from collapsing by setting a minimum width on the React Select container
Fixed issue: https://github.com/hubleto/erp/issues/401
<img width="1523" height="898" alt="image" src="https://github.com/user-attachments/assets/bb681b15-5eb3-4c5c-a6cc-75aa266bd312" />
